### PR TITLE
style: fix view of registration form when both addresses default

### DIFF
--- a/src/app/components/address-form/address.component.html
+++ b/src/app/components/address-form/address.component.html
@@ -99,8 +99,10 @@
         <div class="alert alert-validation">
           @if (code.hasError('required')) {
             {{ addressDefaultInput | titlecase }} postal code is required
-          } @else if (code.hasError('pattern')) {
-            Invalid postal code format
+          } @else if (code.hasError('invalidPostalCodeUS')) {
+            Postal code must be in US format (12345 or 12345-6789)
+          } @else if (code.hasError('invalidPostalCodeBY')) {
+            Postal code must be in Belarus format (6 digits)
           }
         </div>
       }

--- a/src/app/components/address-form/address.component.ts
+++ b/src/app/components/address-form/address.component.ts
@@ -12,6 +12,7 @@ import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { Countries } from '@models/enums';
 import { CommonModule } from '@angular/common';
 import { AddressResponse } from '@models/types';
+import { postalCodeValidator } from '@validators/postal_code';
 
 @Component({
   selector: 'app-address-form',
@@ -39,10 +40,7 @@ export class AddressComponent implements OnInit, OnChanges {
       Validators.pattern(/^[A-Za-z0-9!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?`~\s]+$/),
     ]),
     city: new FormControl('', [Validators.required, Validators.pattern(/^[A-Za-z\s]+$/)]),
-    postalCode: new FormControl('', [
-      Validators.required,
-      Validators.pattern(/^\d{5}(-\d{4})?$|^\d{6}$/),
-    ]),
+    postalCode: new FormControl('', [Validators.required, postalCodeValidator]),
     addressDefault: new FormControl(''),
     bothAddressesDefault: new FormControl(''),
   });

--- a/src/app/pages/registration-page/registration-page.component.html
+++ b/src/app/pages/registration-page/registration-page.component.html
@@ -5,7 +5,14 @@
 >
   <h1>Sign Up</h1>
 
-  <div class="login-form__container">
+  <div
+    class="login-form__container"
+    [ngClass]="
+      isShippingBillingAddressDefault() || isBillingShippingAddressDefault()
+        ? 'one-address-default'
+        : ''
+    "
+  >
     <div class="login-form__info">
       <app-email-field [control]="email"></app-email-field>
 

--- a/src/app/pages/registration-page/registration-page.component.scss
+++ b/src/app/pages/registration-page/registration-page.component.scss
@@ -43,11 +43,25 @@
   grid-template-columns: repeat(3, 1fr);
   grid-template-areas: 'info shipping billing';
 
+  &.one-address-default {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
   @media screen and (max-width: 980px) {
     grid-template-columns: 1fr 1fr;
     grid-template-areas:
       'info info'
       'shipping billing';
+  }
+
+  @media screen and (max-width: 980px) {
+    &.one-address-default {
+      grid-template-columns: 1fr !important;
+      grid-template-areas:
+        'info'
+        'shipping'
+        'billing';
+    }
   }
 
   @media screen and (max-width: 730px) {

--- a/src/app/pages/registration-page/registration-page.component.ts
+++ b/src/app/pages/registration-page/registration-page.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, WritableSignal } from '@angular/core';
 import { MatButton } from '@angular/material/button';
-import { NgIf } from '@angular/common';
+import { CommonModule, NgIf } from '@angular/common';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { signal } from '@angular/core';
@@ -26,6 +26,7 @@ import { latinValidator } from '@validators/latin';
     EmailFieldComponent,
     PasswordFieldComponent,
     DateFieldComponent,
+    CommonModule,
   ],
   templateUrl: './registration-page.component.html',
   styleUrl: './registration-page.component.scss',

--- a/src/app/validators/index.ts
+++ b/src/app/validators/index.ts
@@ -2,3 +2,4 @@ export * from './email';
 export * from './password';
 export * from './age';
 export * from './latin';
+export * from './postal_code';

--- a/src/app/validators/postal_code/index.ts
+++ b/src/app/validators/postal_code/index.ts
@@ -1,0 +1,1 @@
+export * from './postalCode.validator';

--- a/src/app/validators/postal_code/postalCode.validator.ts
+++ b/src/app/validators/postal_code/postalCode.validator.ts
@@ -1,0 +1,24 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+export const postalCodeValidator: ValidatorFn = (
+  control: AbstractControl,
+): ValidationErrors | null => {
+  if (!control || !control.parent) return null;
+
+  const country = control.parent.get('country')?.value;
+  const postalCode = control.value;
+
+  if (!country || !postalCode) return null;
+
+  const usRegex = /^\d{5}(-\d{4})?$/;
+  const byRegex = /^\d{6}$/;
+
+  switch (country) {
+    case 'US':
+      return usRegex.test(postalCode) ? null : { invalidPostalCodeUS: true };
+    case 'BY':
+      return byRegex.test(postalCode) ? null : { invalidPostalCodeBY: true };
+    default:
+      return null;
+  }
+};


### PR DESCRIPTION
1. Tasks Name: Пофиксить форму регистрации, чтобы нормально отображалось, Исправить валидацию на post code
2. Tasks link in Jira: [EA-120](https://deadline-witnesses.atlassian.net/browse/EA-120), [EA-121](https://deadline-witnesses.atlassian.net/browse/EA-121)
3. Description: При выборе опции "Use as default shipping and billing address" реализовано корректное отображение без пустых ячеек в grid разметке. Также исправлена валидация post code, валидация зависит от выбранной страны
4. Screenshot: 

### Отображение формы регистрации
![image](https://github.com/user-attachments/assets/a096670c-66a2-4f84-aff3-63bb360b354a)


### Валидация post code
![image](https://github.com/user-attachments/assets/9e800ab6-197f-4a87-8248-2ce20ed1eb0a)
